### PR TITLE
Fix comment spacing in HTF blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# Repository Guidelines
+
+The codebase follows a simple documenting style similar to **htf.mqh**.
+Use three-line comment blocks before classes and functions and
+place method implementations outside the class definition when possible.
+Example comment block:
+```mq4
+//+------------------------------------------------------------------+
+//| Short description                                                |
+//+------------------------------------------------------------------+
+```
+All new MQL4 files should keep this style with short descriptions for
+methods.

--- a/Marge-02.mq4
+++ b/Marge-02.mq4
@@ -1,0 +1,72 @@
+//+------------------------------------------------------------------+
+//| Marge-02.mq4                                                     |
+//| Copyright 2025, Никита Сердитов                    |
+//| https://t.me/mashida                                             |
+//+------------------------------------------------------------------+
+#property strict
+#property indicator_separate_window
+#property indicator_buffers 2
+#property indicator_color1 clrBlue
+#property indicator_width1 2
+#property indicator_style1 STYLE_SOLID
+
+#include "HighTFAggregator.mqh"
+#include "OsmaOnArray.mqh"
+
+//--- входные параметры
+input int HigherTFMinutes = 60;         // Старший таймфрейм в минутах
+input int OsMA_FastEMA    = 12;         // Быстрая EMA для OsMA
+input int OsMA_SlowEMA    = 26;         // Медленная EMA для OsMA
+input int OsMA_SignalSMA  = 9;          // Сигнальная SMA для OsMA
+
+//--- буферы индикатора
+double OsMA_Buffer[];       // буфер для OsMA
+double CloseHTF_Buffer[];   // буфер цены Close старшего таймфрейма
+
+//--- глобальные объекты
+CHighTfAggregator aggregator;
+COsMAOnArray      osma;
+
+//+------------------------------------------------------------------+
+//| Инициализация индикатора                                         |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   // Устанавливаем буферы
+   SetIndexBuffer(0, OsMA_Buffer, INDICATOR_DATA);
+   SetIndexBuffer(1, CloseHTF_Buffer, INDICATOR_CALCULATIONS);
+   ArraySetAsSeries(OsMA_Buffer, true);
+   ArraySetAsSeries(CloseHTF_Buffer, true);
+
+   SetIndexStyle(0, DRAW_HISTOGRAM, STYLE_SOLID, 2, clrBlue);
+   SetIndexLabel(0, "OsMA HTF");
+
+   aggregator.Init(HigherTFMinutes);
+   osma.Init(OsMA_FastEMA, OsMA_SlowEMA, OsMA_SignalSMA);
+
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Основная функция расчета                                         |
+//+------------------------------------------------------------------+
+int OnCalculate(const int rates_total,
+                const int prev_calculated,
+                const datetime &time[],
+                const double &open[],
+                const double &high[],
+                const double &low[],
+                const double &close[],
+                const long &tick_volume[],
+                const long &volume[],
+                const int &spread[])
+  {
+   // получаем закрытия старшего таймфрейма
+   aggregator.Calculate(rates_total, prev_calculated, CloseHTF_Buffer);
+
+   // рассчитываем OsMA с помощью отдельного объекта
+   osma.OnCalculate(rates_total, prev_calculated, CloseHTF_Buffer, OsMA_Buffer);
+
+   return(rates_total);
+  }
+//+------------------------------------------------------------------+

--- a/OsmaOnArray.mqh
+++ b/OsmaOnArray.mqh
@@ -1,0 +1,95 @@
+//+------------------------------------------------------------------+
+//| OsmaOnArray.mqh                                                  |
+//| Helper class to compute OsMA on small arrays using iMAOnArray    |
+//+------------------------------------------------------------------+
+#ifndef __OSMAONARRAY_MQH__
+#define __OSMAONARRAY_MQH__
+#property strict
+
+//+------------------------------------------------------------------+
+//| OsMA calculation on array                                        |
+//+------------------------------------------------------------------+
+class COsMAOnArray
+  {
+private:
+   int m_fast;    // Fast EMA period
+   int m_slow;    // Slow EMA period
+   int m_signal;  // Signal SMA period
+
+public:
+   // Инициализация периодов
+   void Init(int fast,int slow,int signal);
+
+   // Расчёт OsMA по буферу close
+   int  OnCalculate(const int rates_total,
+                    const int prev_calculated,
+                    const double &close[],
+                    double &osma[]);
+  };
+
+//+------------------------------------------------------------------+
+//| Инициализация                                       |
+//+------------------------------------------------------------------+
+void COsMAOnArray::Init(int fast,int slow,int signal)
+  {
+   m_fast   = fast;
+   m_slow   = slow;
+   m_signal = signal;
+  }
+
+//+------------------------------------------------------------------+
+//| Основной расчёт OsMA                               |
+//+------------------------------------------------------------------+
+int COsMAOnArray::OnCalculate(const int rates_total,
+                              const int prev_calculated,
+                              const double &close[],
+                              double &osma[])
+  {
+   int start = prev_calculated>0 ? prev_calculated-1 : 0;
+
+   static double raw[];
+   ArrayResize(raw,rates_total);
+   ArraySetAsSeries(raw,true);
+
+   double arrFast[];
+   double arrSlow[];
+   double arrSignal[];
+   ArrayResize(arrFast,m_fast);
+   ArrayResize(arrSlow,m_slow);
+   ArrayResize(arrSignal,m_signal);
+   ArraySetAsSeries(arrFast,true);
+   ArraySetAsSeries(arrSlow,true);
+   ArraySetAsSeries(arrSignal,true);
+
+   for(int i=start;i<rates_total;i++)
+     {
+      if(i+m_slow>rates_total)
+        {
+         raw[i]=EMPTY_VALUE;
+         continue;
+        }
+      for(int j=0;j<m_fast;j++)
+         arrFast[j] = close[i+j];
+      double emaFast = iMAOnArray(arrFast,m_fast,m_fast,0,MODE_EMA,0);
+      for(int j=0;j<m_slow;j++)
+         arrSlow[j] = close[i+j];
+      double emaSlow = iMAOnArray(arrSlow,m_slow,m_slow,0,MODE_EMA,0);
+      raw[i] = emaFast - emaSlow;
+     }
+
+   for(int i=start;i<rates_total;i++)
+     {
+      if(raw[i]==EMPTY_VALUE || i+m_signal>rates_total)
+        {
+         osma[i]=EMPTY_VALUE;
+         continue;
+        }
+      for(int j=0;j<m_signal;j++)
+         arrSignal[j]=raw[i+j];
+      double signal = iMAOnArray(arrSignal,m_signal,m_signal,0,MODE_SMA,0);
+      osma[i] = raw[i] - signal;
+     }
+   return(rates_total);
+  }
+
+#endif // __OSMAONARRAY_MQH__


### PR DESCRIPTION
## Summary
- adjust HTF-style comment blocks in `OsmaOnArray.mqh`
- clean up header comment spacing in `Marge-02.mq4`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687c8e02146c83268f4c1fcafe20755b