### PR TITLE
Add Marg-03 indicator using HTF

### DIFF
--- a/Marg-03.mq4
+++ b/Marg-03.mq4
@@ -1,0 +1,71 @@
+//+------------------------------------------------------------------+
+//| Marg-03.mq4                                                      |
+//| Copyright 2025, Никита Сердитов                                  |
+//| https://t.me/mashida                                             |
+//+------------------------------------------------------------------+
+#property strict
+#property indicator_separate_window
+#property indicator_buffers 2
+#property indicator_color1 clrBlue
+#property indicator_width1 2
+#property indicator_style1 STYLE_SOLID
+
+#include "htf.mqh"
+#include "OsmaOnArray.mqh"
+
+//--- входные параметры
+input int HigherTFMinutes = 60;         // Старший таймфрейм в минутах
+input int OsMA_FastEMA    = 12;         // Быстрая EMA для OsMA
+input int OsMA_SlowEMA    = 26;         // Медленная EMA для OsMA
+input int OsMA_SignalSMA  = 9;          // Сигнальная SMA для OsMA
+
+//--- буферы индикатора
+double OsMA_Buffer[];       // буфер для OsMA
+double CloseHTF_Buffer[];   // буфер цены Close старшего таймфрейма
+
+//--- глобальные объекты
+CHTF            htf;
+COsMAOnArray    osma;
+
+//+------------------------------------------------------------------+
+//| Инициализация индикатора                                         |
+//+------------------------------------------------------------------+
+int OnInit()
+  {
+   SetIndexBuffer(0, OsMA_Buffer, INDICATOR_DATA);
+   SetIndexBuffer(1, CloseHTF_Buffer, INDICATOR_CALCULATIONS);
+   ArraySetAsSeries(OsMA_Buffer, true);
+   ArraySetAsSeries(CloseHTF_Buffer, true);
+
+   SetIndexStyle(0, DRAW_HISTOGRAM, STYLE_SOLID, 2, clrBlue);
+   SetIndexLabel(0, "OsMA HTF");
+
+   htf.SaveInputs(0, HigherTFMinutes);
+   htf.OnInitCalc();
+   osma.Init(OsMA_FastEMA, OsMA_SlowEMA, OsMA_SignalSMA);
+
+   return(INIT_SUCCEEDED);
+  }
+
+//+------------------------------------------------------------------+
+//| Основная функция расчета                                         |
+//+------------------------------------------------------------------+
+int OnCalculate(const int rates_total,
+                const int prev_calculated,
+                const datetime &time[],
+                const double &open[],
+                const double &high[],
+                const double &low[],
+                const double &close[],
+                const long &tick_volume[],
+                const long &volume[],
+                const int &spread[])
+  {
+   htf.Calc(rates_total, prev_calculated);
+   htf.CopyCloseBuffer(rates_total, CloseHTF_Buffer);
+
+   osma.OnCalculate(rates_total, prev_calculated, CloseHTF_Buffer, OsMA_Buffer);
+
+   return(rates_total);
+  }
+//+------------------------------------------------------------------+

--- a/htf.mqh
+++ b/htf.mqh
@@ -284,4 +284,23 @@ void CHTF::Calc(const int RATES_TOTAL,const int PREV_CALCULATED)
   }
 
 
+//+------------------------------------------------------------------+
+//| Copy close prices of HTF bars to buffer                           |
+//+------------------------------------------------------------------+
+void CHTF::CopyCloseBuffer(int rates_total,double &buffer[])
+  {
+   ArrayResize(buffer,rates_total);
+   ArraySetAsSeries(buffer,true);
+
+   CBarStorage *cur=m_rates.GetNodeAtIndex(0);
+   for(int i=0;i<rates_total;i++)
+     {
+      datetime t=Time[i];
+      while(cur.Prev()!=NULL && t<cur.timeOpenReal)
+         cur=cur.Prev();
+      buffer[i]=cur.close;
+     }
+  }
+
+
 #endif // __HTF_MQH__


### PR DESCRIPTION
## Summary
- add a helper method `CopyCloseBuffer` in `htf.mqh` to export close prices
- create `Marg-03.mq4` indicator that relies on `htf.mqh`

## Testing
- `echo "No tests" && ls`

------
https://chatgpt.com/codex/tasks/task_e_687c945142288326ac7a6fe7253da7fd